### PR TITLE
apikeyを入力できない問題の修正

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -48,7 +48,7 @@ const saveApiKey = () => {
   const current = localStorage.getItem("api_key");
   const apiKey = prompt(
     `APIキーを入力してください(空白で削除, 現在 ${
-      current === undefined ? "未設定" : current.slice(0, 4) + "..."
+      current === null ? "未設定" : current.slice(0, 4) + "..."
     })`
   );
   if (apiKey === null) {


### PR DESCRIPTION
apikeyを入力させる部分が正常に動作しない状態となっていたため、軽微な修正を行いました。
変更後のコードを使用し、自分のapikeyで動作すること(OPENAIのAPI DashboardでUsageが加算されること)を確認しています。